### PR TITLE
fix(storage): preserve language preference on logout

### DIFF
--- a/src/app/auth/services/authentication.service.ts
+++ b/src/app/auth/services/authentication.service.ts
@@ -89,7 +89,6 @@ export class AuthenticationService<T> {
   private clearStorage = (): void => {
     localStorage.removeItem(this.AUTH_TOKEN);
     localStorage.removeItem(this.AUTH_DETAILS);
-    localStorage.clear();
   };
 
   private getToken = (): string | null => {

--- a/src/app/services/language.service.ts
+++ b/src/app/services/language.service.ts
@@ -19,13 +19,14 @@ export class LanguageService {
     private authenticationService: AuthenticationService<CustomDetails>,
     private http: HttpClient
   ) {}
+  readonly STORED_LANGUAGE: string = 'language';
 
   /**
    * Get the current language from localStorage or default from configuration
    * This is the preferred method over getDefaultLanguage() as it's more explicit
    */
   getCurrentLanguage(): string {
-    const storedLang = localStorage.getItem('language');
+    const storedLang = localStorage.getItem(this.STORED_LANGUAGE);
     return storedLang ?? this.appConfigService.getDefaultLanguage();
   }
 
@@ -54,8 +55,7 @@ export class LanguageService {
    */
   setLanguage(lang: string, syncBackend: boolean = true): Observable<void> {
     // Update localStorage
-    localStorage.setItem('language', lang);
-
+    localStorage.setItem(this.STORED_LANGUAGE, lang);
     // Update TranslateService
     this.translateService.use(lang);
 


### PR DESCRIPTION
* Avoid clearing language setting when user logs out.
* Define language localStorage key as readonly constant

Related to issue #132
